### PR TITLE
Max streak, correct implementation

### DIFF
--- a/models/nba/analysis/schema.yml
+++ b/models/nba/analysis/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: nba_team_stats
+    description: Aggregated statistics for NBA teams including win streaks
+    columns:
+      - name: max_win_streak
+        description: The longest win streak for each team in a given season
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"  # Ensures the streak is always greater than or equal to 0
+          - accepted_values:
+              values: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33]  # Based on historical NBA data, no team has ever had a streak longer than 33 games (1971-72 Lakers)

--- a/tests/validate_win_streaks.py
+++ b/tests/validate_win_streaks.py
@@ -1,0 +1,115 @@
+import duckdb
+import pandas as pd
+import numpy as np
+
+def calculate_win_streaks(df, team_col, opp_col, score_col, opp_score_col):
+    """Calculate win streaks for each team within each season."""
+    # Sort by date to ensure chronological order
+    df = df.sort_values('date')
+    
+    # Determine if team won
+    df['won'] = (df[score_col] > df[opp_score_col]).astype(int)
+    
+    # Initialize streak counting
+    df['current_streak'] = 0
+    
+    # Calculate streaks for each team in each season
+    for season in df['season'].unique():
+        for team in df[df['season'] == season][team_col].unique():
+            team_mask = (df['season'] == season) & (df[team_col] == team)
+            team_games = df[team_mask].copy()
+            
+            current_streak = 0
+            max_streak = 0
+            
+            for idx, row in team_games.iterrows():
+                if row['won'] == 1:
+                    current_streak += 1
+                    max_streak = max(max_streak, current_streak)
+                else:
+                    current_streak = 0
+                df.loc[idx, 'current_streak'] = current_streak
+            
+            df.loc[team_mask, 'max_streak'] = max_streak
+    
+    # Get max streak per team per season
+    max_streaks = df.groupby(['season', team_col])['max_streak'].max().reset_index()
+    max_streaks = max_streaks.rename(columns={'max_streak': 'streak_value'})
+    return max_streaks
+
+def main():
+    # Connect to DuckDB
+    conn = duckdb.connect('/workspace/nba-dbt/mdsbox.duckdb')
+    
+    # Load data from elo_history
+    elo_history = conn.execute("""
+        SELECT 
+            date,
+            season,
+            team1 as team,
+            team2 as opponent,
+            score1 as team_score,
+            score2 as opp_score,
+            playoff
+        FROM mdsbox.nba_elo_history
+        WHERE playoff = 'r'
+        UNION ALL
+        SELECT 
+            date,
+            season,
+            team2 as team,
+            team1 as opponent,
+            score2 as team_score,
+            score1 as opp_score,
+            playoff
+        FROM mdsbox.nba_elo_history
+        WHERE playoff = 'r'
+        ORDER BY date
+    """).fetchdf()
+    
+    # Calculate win streaks using our Python implementation
+    python_streaks = calculate_win_streaks(
+        elo_history,
+        'team',
+        'opponent',
+        'team_score',
+        'opp_score'
+    )
+    
+    # Get SQL implementation results
+    sql_streaks = conn.execute("""
+        SELECT 
+            season,
+            team,
+            max_win_streak
+        FROM mdsbox.nba_team_stats
+        ORDER BY season, team
+    """).fetchdf()
+    
+    # Merge and compare results
+    comparison = python_streaks.merge(
+        sql_streaks,
+        on=['season', 'team'],
+        how='outer',
+        suffixes=('_python', '_sql')
+    )
+    
+    # Find discrepancies
+    comparison['difference'] = comparison['streak_value'] - comparison['max_win_streak']
+    discrepancies = comparison[comparison['difference'] != 0]
+    
+    if len(discrepancies) == 0:
+        print("✅ All win streaks match between Python and SQL implementations!")
+    else:
+        print("❌ Found discrepancies between Python and SQL implementations:")
+        print("\nDiscrepancies:")
+        print(discrepancies.to_string(index=False))
+        
+    # Print some interesting statistics
+    print("\nTop 10 longest win streaks:")
+    print(comparison.nlargest(10, 'streak_value')[
+        ['season', 'team', 'streak_value']
+    ].to_string(index=False))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prompt:
```
Add a column max_win_streak to the nba_team_stats model that shows the longest win streak for each team. Use the data from the elo history table.

If you add a new SQL model that is complex, it's a good idea to write a Python script to sanity check the SQL implementation's output.
```

Data:
```
D select * from nba_team_stats order by max_win_streak desc;
┌──────────┬───────┬───────┬────────┬───────────┬─────────────┬───────────┬───┬─────────────────────┬────────────────────┬────────────────────┬────────────────────┬─────────┬────────┬────────────────┐
│   key    │  ct   │ wins  │ losses │ home_wins │ home_losses │ away_wins │ … │       margin        │      min_elo       │      avg_elo       │      max_elo       │  team   │ season │ max_win_streak │
│ varchar  │ int64 │ int64 │ int64  │   int64   │    int64    │   int64   │   │       double        │       double       │       double       │       double       │ varchar │ int64  │     int64      │
├──────────┼───────┼───────┼────────┼───────────┼─────────────┼───────────┼───┼─────────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────┼────────┼────────────────┤
│ LAL:1972 │    97 │    69 │    -13 │        37 │          -5 │        32 │ … │  10.876288659793815 │             1496.0 │ 1686.0927835051546 │             1753.0 │ LAL     │   1972 │             33 │
│ MIA:2013 │   105 │    66 │    -16 │        37 │          -4 │        29 │ … │  7.5523809523809575 │             1611.0 │  1702.952380952381 │             1774.0 │ MIA     │   2013 │             27 │
│ GSW:2016 │   106 │    73 │     -9 │        39 │          -2 │        34 │ … │   9.311320754716988 │             1743.0 │ 1798.1792452830189 │             1839.0 │ GSW     │   2016 │             24 │
│ HOU:2008 │    88 │    55 │    -27 │        31 │         -10 │        24 │ … │   4.193181818181813 │             1535.0 │  1604.159090909091 │             1697.0 │ HOU     │   2008 │             22 │
│ MIL:1971 │    96 │    66 │    -16 │        35 │          -3 │        31 │ … │  12.583333333333329 │             1552.0 │           1669.625 │             1757.0 │ MIL     │   1971 │             20 │
│ LAL:2000 │   105 │    67 │    -15 │        36 │          -5 │        31 │ … │    7.19047619047619 │             1548.0 │  1678.009523809524 │             1779.0 │ LAL     │   2000 │             19 │
│ BOS:2009 │    96 │    62 │    -20 │        35 │          -6 │        27 │ … │   6.416666666666671 │             1654.0 │ 1702.3020833333333 │             1760.0 │ BOS     │   2009 │             19 │
│ ATL:2015 │    98 │    60 │    -22 │        35 │          -6 │        25 │ … │   4.510204081632651 │             1486.0 │ 1606.3265306122448 │             1701.0 │ ATL     │   2015 │             19 │
│ SAS:2014 │   105 │    62 │    -20 │        32 │          -9 │        30 │ … │   8.066666666666663 │             1637.0 │  1695.647619047619 │             1760.0 │ SAS     │   2014 │             19 │
│ NYK:1970 │   101 │    60 │    -22 │        32 │         -12 │        28 │ … │   8.059405940594061 │             1539.0 │ 1635.8415841584158 │             1712.0 │ NYK     │   1970 │             18 │
│ BOS:1982 │    94 │    63 │    -19 │        35 │          -6 │        28 │ … │  6.2872340425531945 │             1635.0 │ 1675.9148936170213 │             1724.0 │ BOS     │   1982 │             18 │
│ CHI:1996 │   100 │    72 │    -10 │        39 │          -2 │        33 │ … │  11.939999999999998 │             1592.0 │             1741.9 │             1853.0 │ CHI     │   1996 │             18 │
│ MIL:2020 │    83 │    56 │    -17 │        30 │          -5 │        26 │ … │    9.01204819277109 │             1633.0 │ 1715.7469879518073 │             1776.0 │ MIL     │   2020 │             18 │
│ PHO:2022 │    95 │    64 │    -18 │        32 │          -9 │        32 │ … │   6.336842105263159 │             1610.0 │ 1686.5684210526315 │             1745.0 │ PHO     │   2022 │             18 │
│ DAL:2007 │    88 │    67 │    -15 │        36 │          -5 │        31 │ … │   6.272727272727266 │             1583.0 │ 1694.9318181818182 │             1773.0 │ DAL     │   2007 │             17 │
│ LAC:2013 │    88 │    56 │    -26 │        32 │          -9 │        24 │ … │   5.636363636363626 │             1548.0 │ 1629.1477272727273 │             1690.0 │ LAC     │   2013 │             17 │
│ WSC:1947 │    66 │    49 │    -11 │        29 │          -1 │        20 │ … │   8.545454545454547 │             1300.0 │ 1435.4545454545455 │             1524.0 │ WSC     │   1947 │             17 │
│ BOS:1960 │    88 │    59 │    -16 │        35 │          -7 │        24 │ … │   7.943181818181813 │             1619.0 │ 1679.6477272727273 │             1728.0 │ BOS     │   1960 │             17 │
│ SAS:1996 │    92 │    59 │    -23 │        33 │          -8 │        26 │ … │    5.33695652173914 │             1603.0 │ 1642.7391304347825 │             1708.0 │ SAS     │   1996 │             17 │
│ PHO:2007 │    93 │    61 │    -21 │        33 │          -8 │        28 │ … │   7.032258064516128 │             1555.0 │ 1656.4086021505377 │             1743.0 │ PHO     │   2007 │             17 │
│    ·     │     · │     · │     ·  │         · │           · │         · │ · │           ·         │                ·   │          ·         │                ·   │  ·      │     ·  │              · │
│    ·     │     · │     · │     ·  │         · │           · │         · │ · │           ·         │                ·   │          ·         │                ·   │  ·      │     ·  │              · │
│    ·     │     · │     · │     ·  │         · │           · │         · │ · │           ·         │                ·   │          ·         │                ·   │  ·      │     ·  │              · │
│ DET:2021 │    72 │    20 │    -52 │        13 │         -23 │         7 │ … │  -4.472222222222214 │             1344.0 │ 1388.3194444444443 │             1427.0 │ DET     │   2021 │              2 │
│ ORL:2022 │    82 │    22 │    -60 │        12 │         -29 │        10 │ … │                -8.0 │             1285.0 │ 1317.4268292682927 │             1371.0 │ ORL     │   2022 │              2 │
│ ATL:2024 │    13 │     6 │     -7 │         4 │          -4 │         2 │ … │  -3.692307692307679 │ 1505.6060172597092 │ 1526.3248728570543 │ 1546.9214417441763 │ ATL     │   2024 │              2 │
│ BRK:2024 │    13 │     5 │     -8 │         3 │          -3 │         2 │ … │ -2.7692307692307736 │  1377.230057123255 │ 1397.7162893837472 │ 1414.6455785912046 │ BRK     │   2024 │              2 │
│ CHI:2024 │    13 │     5 │     -8 │         1 │          -4 │         4 │ … │                -6.0 │ 1449.5374349964043 │ 1469.0810086099368 │ 1486.2933998864507 │ CHI     │   2024 │              2 │
│ CHO:2024 │    12 │     5 │     -7 │         4 │          -3 │         1 │ … │                -4.5 │ 1476.1778913495232 │ 1491.1899612694708 │ 1505.4137564322998 │ CHO     │   2024 │              2 │
│ DAL:2024 │    13 │     6 │     -7 │         5 │          -3 │         1 │ … │                 4.0 │ 1676.3317543412447 │ 1688.9090876069595 │  1699.750807041316 │ DAL     │   2024 │              2 │
│ MIA:2024 │    11 │     5 │     -6 │         1 │          -3 │         4 │ … │ 0.27272727272726627 │ 1604.2968730354535 │ 1612.0197675345903 │             1623.0 │ MIA     │   2024 │              2 │
│ IND:2024 │    12 │     5 │     -7 │         3 │          -2 │         2 │ … │  -3.583333333333343 │ 1622.7759435298549 │ 1633.0589375758416 │  1649.084684164238 │ IND     │   2024 │              2 │
│ POR:2024 │    13 │     5 │     -8 │         3 │          -4 │         2 │ … │  -7.615384615384627 │ 1386.2763220098664 │ 1404.2548641624608 │ 1421.4992568534685 │ POR     │   2024 │              2 │
│ SAS:2024 │    14 │     6 │     -8 │         5 │          -3 │         1 │ … │                -1.0 │ 1543.6229815249933 │  1557.337371083937 │ 1571.7832417451436 │ SAS     │   2024 │              2 │
│ UTA:2024 │    12 │     3 │     -9 │         1 │          -5 │         2 │ … │              -11.25 │  1418.968366830949 │ 1440.8199976371454 │             1482.0 │ UTA     │   2024 │              1 │
│ LAC:1987 │    82 │    12 │    -70 │         9 │         -32 │         3 │ … │ -11.426829268292678 │             1210.0 │ 1312.1341463414635 │             1439.0 │ LAC     │   1987 │              1 │
│ CHO:2012 │    66 │     7 │    -59 │         4 │         -29 │         3 │ … │ -13.909090909090907 │             1155.0 │ 1288.3181818181818 │             1426.0 │ CHO     │   2012 │              1 │
│ MIL:2014 │    82 │    15 │    -67 │        10 │         -31 │         5 │ … │  -8.182926829268297 │             1257.0 │ 1321.3536585365853 │             1456.0 │ MIL     │   2014 │              1 │
│ PHI:2016 │    82 │    10 │    -72 │         7 │         -34 │         3 │ … │ -10.231707317073159 │             1194.0 │ 1249.0975609756097 │             1333.0 │ PHI     │   2016 │              1 │
│ PHI:2024 │    12 │     2 │    -10 │         1 │          -5 │         1 │ … │  -8.333333333333329 │ 1581.7021452417143 │  1622.241619581788 │             1670.0 │ PHI     │   2024 │              1 │
│ TOR:2024 │    14 │     2 │    -12 │         2 │          -4 │         0 │ … │  -7.357142857142861 │  1425.610754055975 │ 1451.2449834776562 │             1473.0 │ TOR     │   2024 │              1 │
│ PRO:1948 │    48 │     6 │    -42 │         2 │         -18 │         4 │ … │            -11.5625 │             1166.0 │ 1242.4791666666667 │             1334.0 │ PRO     │   1948 │              1 │
│ ATL:2005 │    82 │    13 │    -69 │         9 │         -32 │         4 │ … │  -9.707317073170728 │             1202.0 │  1305.158536585366 │             1430.0 │ ATL     │   2005 │              1 │
├──────────┴───────┴───────┴────────┴───────────┴─────────────┴───────────┴───┴─────────────────────┴────────────────────┴────────────────────┴────────────────────┴─────────┴────────┴────────────────┤
│ 1757 rows (40 shown)                                                                                                                                                           19 columns (14 shown) │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```